### PR TITLE
Implement weekly balance and budget tracking

### DIFF
--- a/app.html
+++ b/app.html
@@ -342,8 +342,8 @@
                                 </div>
                                 
                                 <div class="text-center">
-                                    <div class="text-sm text-textSecondary mb-1">Monthly Budget</div>
-                                    <div class="text-lg font-semibold text-textPrimary" id="monthlyBudget"></div>
+                                    <div class="text-sm text-textSecondary mb-1">Weekly Budget</div>
+                                    <div class="text-lg font-semibold text-textPrimary" id="weeklyBudget"></div>
                                 </div>
                             </div>
                         </div>
@@ -1108,6 +1108,7 @@
             // Calculate balance
             const balance = calculateBalance();
             const weeklyStats = calculateWeeklyStats();
+            updateBalanceDate(weeklyStats.range);
             
             // Update balance card
             document.getElementById('currentBalance').textContent = formatCurrency(balance);
@@ -1136,26 +1137,28 @@
         }
 
         function calculateWeeklyStats() {
-            const oneWeekAgo = new Date();
-            oneWeekAgo.setDate(oneWeekAgo.getDate() - 7);
-            
-            const weeklyTransactions = appState.transactions.filter(t => 
-                new Date(t.date) >= oneWeekAgo
-            );
-            
+            const range = getCurrentWeekRange();
+
+            const weeklyTransactions = appState.transactions.filter(t => {
+                const d = new Date(t.date);
+                return d >= range.start && d < range.end;
+            });
+
             return {
                 income: weeklyTransactions.filter(t => t.type === 'income').reduce((sum, t) => sum + t.amount, 0),
-                expenses: weeklyTransactions.filter(t => t.type === 'expense').reduce((sum, t) => sum + t.amount, 0)
+                expenses: weeklyTransactions.filter(t => t.type === 'expense').reduce((sum, t) => sum + t.amount, 0),
+                range
             };
         }
 
         function updateBudgetCompass() {
+            computeWeeklyBudgetSpending();
             const totalBudget = appState.budgets.filter(b => b.active).reduce((sum, b) => sum + b.amount, 0);
             const totalSpent = appState.budgets.filter(b => b.active).reduce((sum, b) => sum + b.spent, 0);
             const percentage = totalBudget > 0 ? Math.round((totalSpent / totalBudget) * 100) : 0;
-            
+
             document.getElementById('budgetPercentage').textContent = `${percentage}%`;
-            document.getElementById('monthlyBudget').textContent = `${formatCurrency(totalSpent)} / ${formatCurrency(totalBudget)}`;
+            document.getElementById('weeklyBudget').textContent = `${formatCurrency(totalSpent)} / ${formatCurrency(totalBudget)}`;
             
             // Update progress circle
             const circle = document.getElementById('budgetProgressCircle');
@@ -1554,6 +1557,7 @@
         }
 
         function renderBudgets() {
+            computeWeeklyBudgetSpending();
             renderBudgetCards();
         }
 
@@ -1914,7 +1918,8 @@
             ctx.stroke();
         }
 
-        function renderVarianceTable() {
+       function renderVarianceTable() {
+            computeWeeklyBudgetSpending();
             const tbody = document.getElementById('varianceTableBody');
             
             tbody.innerHTML = appState.budgets.filter(b => b.active).map(budget => {
@@ -2236,6 +2241,47 @@
 
         function updateCurrencyDisplay() {
             renderCurrentPage();
+        }
+
+        function getCurrentWeekRange() {
+            const now = new Date();
+            const day = now.getDay(); // 0=Sun,1=Mon,2=Tue,...
+            const diff = day >= 2 ? day - 2 : day + 5; // days since Tuesday
+            const start = new Date(now);
+            start.setDate(now.getDate() - diff);
+            start.setHours(0, 0, 0, 0);
+            const end = new Date(start);
+            end.setDate(start.getDate() + 7);
+            return { start, end };
+        }
+
+        function updateBalanceDate(range) {
+            const options = { month: 'short', day: 'numeric' };
+            const startStr = range.start.toLocaleDateString('en-US', options);
+            const endMinus = new Date(range.end);
+            endMinus.setDate(range.end.getDate() - 1);
+            const endStr = endMinus.toLocaleDateString('en-US', options);
+
+            const el = document.getElementById('balanceDate');
+            if (el) {
+                el.textContent = `Week of ${startStr} - ${endStr}`;
+            }
+        }
+
+        function computeWeeklyBudgetSpending() {
+            const range = getCurrentWeekRange();
+            appState.budgets.forEach(b => b.spent = 0);
+            appState.transactions.forEach(t => {
+                const d = new Date(t.date);
+                if (t.type === 'expense' && d >= range.start && d < range.end) {
+                    let budget = appState.budgets.find(b => b.id === t.category);
+                    if (!budget) {
+                        budget = { id: t.category, amount: 0, spent: 0, pinned: false, active: true };
+                        appState.budgets.push(budget);
+                    }
+                    budget.spent += t.amount;
+                }
+            });
         }
 
         function showToast(message, type = 'info') {


### PR DESCRIPTION
## Summary
- display weekly budget totals instead of monthly
- compute weekly balance from Tuesday to Tuesday
- track budget spending based on the current Tuesday‑to‑Tuesday week

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683ff7a63de0832fbea2a78ce7e254d2