### PR TITLE
Fix mobile bottom nav

### DIFF
--- a/app.html
+++ b/app.html
@@ -689,7 +689,7 @@
         </div>
         
         <!-- Bottom Navigation (Mobile) -->
-        <nav class="lg:hidden bg-surface2 border-t border-border">
+        <nav class="lg:hidden fixed bottom-0 left-0 right-0 bg-surface2 border-t border-border z-40">
             <div class="flex items-center justify-around py-2">
                 <a href="#" class="nav-item mobile-nav active flex flex-col items-center p-2 text-xs" data-page="dashboard">
                     <i class="fas fa-home text-lg mb-1"></i>


### PR DESCRIPTION
## Summary
- pin the bottom navigation bar to the bottom of the screen on small devices

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684007033438832f8450932f0d5ec9e3