### PR TITLE
Improve transaction table styling

### DIFF
--- a/app.html
+++ b/app.html
@@ -201,6 +201,15 @@
             animation: slideOut 0.3s ease forwards;
         }
 
+        .tabular-nums {
+            font-variant-numeric: tabular-nums;
+        }
+
+        .transaction-checkbox {
+            width: 14px;
+            height: 14px;
+        }
+
 
     </style>
 </head>
@@ -449,7 +458,7 @@
                                     <thead class="bg-surface4 sticky top-0 z-10">
                                         <tr>
                                             <th class="w-12 px-6 py-4 text-left text-sm font-semibold text-textSecondary uppercase tracking-wider">
-                                                <input type="checkbox" id="selectAllTransactions" class="focus-ring rounded border-border">
+                                                <input type="checkbox" id="selectAllTransactions" class="transaction-checkbox focus-ring rounded border-border">
                                             </th>
                                             <th class="w-32 px-6 py-4 text-left text-sm font-semibold text-textSecondary uppercase tracking-wider cursor-pointer select-none" data-sort="date" aria-sort="none">
                                                 <span class="inline-flex items-center">
@@ -1397,12 +1406,13 @@
             const tbody = document.getElementById('transactionsTableBody');
             const transactions = getFilteredTransactions();
             
-            tbody.innerHTML = transactions.map(t => {
+            tbody.innerHTML = transactions.map((t, idx) => {
                 const category = appState.categories.find(c => c.id === t.category);
                 const isSelected = appState.selectedTransactions.has(t.id);
-                
+                const rowBg = isSelected ? 'bg-primary/5' : (idx % 2 === 0 ? 'bg-surface3' : 'bg-surface2');
+
                 return `
-                    <tr data-id="${t.id}" class="transactions-row group ${isSelected ? 'bg-primary/5' : 'bg-surface3'}">
+                    <tr data-id="${t.id}" class="transactions-row group ${rowBg}">
                         <td class="px-4 py-3 first:rounded-l-md">
                             <input type="checkbox" class="transaction-checkbox focus-ring rounded border-border opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity" data-id="${t.id}" ${isSelected ? 'checked' : ''}>
                         </td>
@@ -1413,11 +1423,11 @@
                             ${t.merchant}
                         </td>
                         <td class="px-4 py-3">
-                            <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium" style="background:${category?.color}1A;color:${category?.color}">
+                            <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium" style="background:${category?.color}33;color:${category?.color}">
                                 ${category?.icon || '💰'} <span class="ml-1">${category?.name || 'Other'}</span>
                             </span>
                         </td>
-                        <td class="px-4 py-3 text-right font-mono text-base font-semibold ${t.type === 'income' ? 'text-green-400' : 'text-red-500'}">
+                        <td class="px-4 py-3 text-right font-mono tabular-nums text-base font-bold ${t.type === 'income' ? 'text-green-400' : 'text-red-500'}">
                             ${t.type === 'income' ? '+' : '-'}${formatCurrency(t.amount)}
                         </td>
                         <td class="px-4 py-3 last:rounded-r-md">


### PR DESCRIPTION
## Summary
- alternate transaction row colors for easier scanning
- lighten category pill backgrounds
- align numbers using `tabular-nums` and make amounts bold
- standardize checkbox size with a new utility class

## Testing
- `npm test` *(fails: no `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_684026e26cdc832fa7a89dd80fbb89d5