### PR TITLE
Fix table row color in dark mode

### DIFF
--- a/app.html
+++ b/app.html
@@ -1409,7 +1409,7 @@
             tbody.innerHTML = transactions.map((t, idx) => {
                 const category = appState.categories.find(c => c.id === t.category);
                 const isSelected = appState.selectedTransactions.has(t.id);
-                const rowBg = isSelected ? 'bg-primary/5' : 'bg-white';
+                const rowBg = isSelected ? 'bg-primary/5' : 'bg-surface1';
 
                 return `
                     <tr data-id="${t.id}" class="transactions-row group ${rowBg}">


### PR DESCRIPTION
## Summary
- ensure transaction table rows inherit dark theme surface color

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684029b10444832fb9bc67730844c281