### PR TITLE
Add daily closing balance rows

### DIFF
--- a/app.html
+++ b/app.html
@@ -1423,40 +1423,32 @@
         function renderTransactionsTable() {
             const tbody = document.getElementById('transactionsTableBody');
             const transactions = getFilteredTransactions();
-            
+
             tbody.innerHTML = transactions.map((t, idx) => {
                 const category = appState.categories.find(c => c.id === t.category);
+                const isClosing = t.type === 'closing';
                 const isSelected = appState.selectedTransactions.has(t.id);
                 const rowBg = isSelected ? 'bg-primary/5' : (idx % 2 === 0 ? 'bg-surface1' : 'bg-[#FAFAFA]');
 
                 return `
                     <tr data-id="${t.id}" class="transactions-row group ${rowBg}">
                         <td class="px-3 py-3 text-center first:rounded-l-md">
-                            <input type="checkbox" class="transaction-checkbox focus-ring rounded border-border opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity" data-id="${t.id}" ${isSelected ? 'checked' : ''}>
+                            ${isClosing ? '' : `<input type="checkbox" class="transaction-checkbox focus-ring rounded border-border opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity" data-id="${t.id}" ${isSelected ? 'checked' : ''}>`}
                         </td>
                         <td class="px-4 py-3 text-xs font-mono uppercase text-textSecondary">
                             ${formatDate(t.date)}
                         </td>
                         <td class="px-4 py-3 font-semibold text-textPrimary">
-                            ${t.merchant}
+                            ${isClosing ? 'Closing Balance' : t.merchant}
                         </td>
                         <td class="px-4 py-3">
-                            <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium" style="background:${category?.color}26;color:${category?.color}">
-                                ${category?.icon || '💰'} <span class="ml-1">${category?.name || 'Other'}</span>
-                            </span>
+                            ${isClosing ? '<span class="text-xs text-textSecondary">—</span>' : `<span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium" style="background:${category?.color}26;color:${category?.color}">${category?.icon || '💰'} <span class="ml-1">${category?.name || 'Other'}</span></span>`}
                         </td>
-                        <td class="px-4 py-3 text-right font-mono tabular-nums text-base font-semibold ${t.type === 'income' ? 'text-green-400' : 'text-red-500'}">
-                            ${t.type === 'income' ? '+' : '-'}${formatCurrency(t.amount)}
+                        <td class="px-4 py-3 text-right font-mono tabular-nums text-base font-semibold ${isClosing ? 'text-textSecondary' : (t.type === 'income' ? 'text-green-400' : 'text-red-500')}">
+                            ${isClosing ? formatCurrency(t.amount) : `${t.type === 'income' ? '+' : '-'}${formatCurrency(t.amount)}`}
                         </td>
                         <td class="px-4 py-3 last:rounded-r-md">
-                            <div class="flex items-center space-x-2 row-chrome opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
-                                <button onclick="editTransaction(${t.id})" aria-label="Edit" class="focus-ring p-2 rounded-md text-primary hover:bg-surface4 transition-colors">
-                                    <i class="fas fa-edit"></i>
-                                </button>
-                                <button onclick="deleteTransaction(${t.id})" aria-label="Delete" class="focus-ring p-2 rounded-md text-danger hover:bg-surface4 transition-colors">
-                                    <i class="fas fa-trash"></i>
-                                </button>
-                            </div>
+                            ${isClosing ? '' : `<div class="flex items-center space-x-2 row-chrome opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity"><button onclick="editTransaction(${t.id})" aria-label="Edit" class="focus-ring p-2 rounded-md text-primary hover:bg-surface4 transition-colors"><i class="fas fa-edit"></i></button><button onclick="deleteTransaction(${t.id})" aria-label="Delete" class="focus-ring p-2 rounded-md text-danger hover:bg-surface4 transition-colors"><i class="fas fa-trash"></i></button></div>`}
                         </td>
                     </tr>
                 `;
@@ -1506,7 +1498,23 @@
             container.innerHTML = transactions.map(t => {
                 const category = appState.categories.find(c => c.id === t.category);
                 const isSelected = appState.selectedTransactions.has(t.id);
-                
+                const isClosing = t.type === 'closing';
+
+                if (isClosing) {
+                    return `
+                        <div class="transaction-card bg-surface2 rounded-lg p-4 shadow-md relative">
+                            <div class="flex justify-between items-center">
+                                <div class="font-medium text-textPrimary truncate">Closing Balance</div>
+                                <div class="font-mono text-base font-semibold text-textSecondary">${formatCurrency(t.amount)}</div>
+                            </div>
+                            <div class="mt-1 flex items-center justify-between text-sm">
+                                <span class="font-mono text-textSecondary">${formatDate(t.date)}</span>
+                                <span class="text-textSecondary">Balance</span>
+                            </div>
+                        </div>
+                    `;
+                }
+
                 return `
                     <div class="transaction-card bg-surface2 rounded-lg p-4 shadow-md relative ${isSelected ? 'ring-2 ring-primary' : ''} group" data-id="${t.id}">
                         <div class="flex justify-between items-center">
@@ -1586,8 +1594,52 @@
             `).join('');
         }
 
+        function generateClosingEntries(transactions) {
+            if (transactions.length === 0) return [];
+
+            const entriesByDate = {};
+            transactions.forEach(t => {
+                const d = new Date(t.date);
+                const key = d.toISOString().split('T')[0];
+                if (!entriesByDate[key]) entriesByDate[key] = [];
+                entriesByDate[key].push(t);
+            });
+
+            const firstDate = new Date(Math.min(...transactions.map(t => new Date(t.date))));
+            firstDate.setHours(0,0,0,0);
+            const today = new Date();
+            today.setHours(0,0,0,0);
+
+            let current = new Date(firstDate);
+            let balance = 0;
+            const closings = [];
+
+            while (current < today) {
+                const key = current.toISOString().split('T')[0];
+                const daily = entriesByDate[key] || [];
+                daily.forEach(tr => {
+                    balance += tr.type === 'income' ? tr.amount : -tr.amount;
+                });
+                const next = new Date(current);
+                next.setDate(current.getDate() + 1);
+                closings.push({
+                    id: `closing-${next.toISOString().split('T')[0]}`,
+                    type: 'closing',
+                    date: next.toISOString().split('T')[0],
+                    merchant: 'Closing Balance',
+                    category: 'closing',
+                    amount: balance
+                });
+                current.setDate(current.getDate() + 1);
+            }
+
+            return closings;
+        }
+
         function getFilteredTransactions() {
-            let filtered = [...appState.transactions];
+            const baseTransactions = appState.transactions.filter(t => t.type !== 'closing');
+            const closingEntries = generateClosingEntries(baseTransactions);
+            let filtered = baseTransactions.concat(closingEntries);
             
             // Search filter
             const searchTerm = document.getElementById('transactionSearch')?.value.toLowerCase() || '';
@@ -1646,6 +1698,15 @@
                 if (appState.sortField === 'date') {
                     valA = new Date(valA);
                     valB = new Date(valB);
+
+                    if (valA.getTime() === valB.getTime()) {
+                        if (a.type === 'closing' && b.type !== 'closing') {
+                            return appState.sortDirection === 'asc' ? -1 : 1;
+                        }
+                        if (b.type === 'closing' && a.type !== 'closing') {
+                            return appState.sortDirection === 'asc' ? 1 : -1;
+                        }
+                    }
                 }
 
                 if (valA < valB) return appState.sortDirection === 'asc' ? -1 : 1;


### PR DESCRIPTION
## Summary
- insert synthetic closing balance entries via `generateClosingEntries`
- show "Closing Balance" in transaction tables and cards
- ensure closing rows sort correctly

## Testing
- `node -v`
- `npm -v`


------
https://chatgpt.com/codex/tasks/task_e_684030af8580832fa27472613383c9a9