### PR TITLE
Fix transaction row border color

### DIFF
--- a/app.html
+++ b/app.html
@@ -1693,9 +1693,9 @@
         } else {
             let rowClasses = "transactions-row group";
             if (t.type === 'income') {
-                rowClasses += " border-l-2 border-green-400";
+                rowClasses += " border-l-2 border-l-green-400";
             } else if (t.type === 'expense') {
-                rowClasses += " border-l-2 border-red-400";
+                rowClasses += " border-l-2 border-l-red-400";
             }
             if (isSelected) {
                 rowClasses += " bg-selected-row";


### PR DESCRIPTION
## Summary
- ensure transaction row border colors only apply to the left edge

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684078c3bd10832f97a02f92efa1989e